### PR TITLE
::std opcional: C++, selecion de current file automatico

### DIFF
--- a/constants/constants.js
+++ b/constants/constants.js
@@ -34,7 +34,7 @@ const LANG = {
   },
   c_plus_plus: {
     regex: {
-      allOutputs: /\s*std::cout\s*<<\s*(?:[^;]*|\([^()]*\))*;?/,
+      allOutputs: /\s*(?:std::)?cout\s*<<\s*(?:[^;]*|\([^()]*\))*;?/,
     },
     extensions: ['cpp', 'hpp'],
     label: 'C++',

--- a/extension.js
+++ b/extension.js
@@ -6,21 +6,17 @@ const { LANG } = require('./constants/constants.js');
 async function activate(context) {
   initializeRegisterCommands(context)
 
+  // Eliminar el oput en el archivo actual
   const clearAllOutputsCommandFile = vscode.commands.registerCommand('clear-outputs-file', function () {
-    vscode.window.showQuickPick(
-      Object.keys(LANG).map(lang => {
-        return {
-          label: LANG[lang].label,
-          command: `clear-outputs-file-${LANG[lang].subfix_command}`,
-          description: `(${LANG[lang].extensions.join(', ')})`
-        }
-      }),
-      { placeHolder: 'Select a language to clear outputs' }
-    ).then(selection => {
-      if (selection) {
-        vscode.commands.executeCommand(selection.command);
-      }
-    });
+    const currentFile = vscode.window.activeTextEditor.document.fileName;
+    const fileExtension = currentFile.split('.').pop();
+    const lang = Object.keys(LANG).find(lang => LANG[lang].extensions.includes(fileExtension));
+
+    if (lang) {
+      vscode.commands.executeCommand(`clear-outputs-file-${LANG[lang].subfix_command}`);
+    } else {
+      vscode.window.showInformationMessage('No matching language found for the current file extension.');
+    }
   });
 
   const clearAllOutputsCommandProject = vscode.commands.registerCommand('clear-outputs-project', function () {

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,15 +1,88 @@
+const vscode = require('vscode');
 const assert = require('assert');
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-const vscode = require('vscode');
-// const myExtension = require('../extension');
+const fs = require('fs');
+const path = require('path');
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	// verificar que el comando clear-outputs-file se ejecute correctamente en visual studio code
+	test('clear-outputs-file command', async () => {
+		const command = 'clear-outputs-file';
+		const executedCommands = [];
+
+		// Mockear la función executeCommand
+		const originalExecuteCommand = vscode.commands.executeCommand;
+		vscode.commands.executeCommand = (cmd) => {
+			executedCommands.push(cmd);
+			return Promise.resolve();
+		};
+
+		// Ejecutar el comando
+		await vscode.commands.executeCommand(command);
+
+		// Restaurar la función executeCommand
+		vscode.commands.executeCommand = originalExecuteCommand;
+
+		// Verificar si se ejecutó el comando correcto
+		assert.ok(executedCommands.includes('clear-outputs-file'));
+	});
+
+	// Verificar que el comando clear-outputs-project se ejecute correctamente en javascript
+	test('clear-outputs-file removes console.log', async () => {
+		// Ruta del archivo de prueba y su contenido
+		const testFilePath = path.join(__dirname, 'testFile.js');
+		const testContent = 'console.log("test");';
+
+		// Create a test file with console.log
+		fs.writeFileSync(testFilePath, testContent);
+
+		// Open the test file in the editor
+		const document = await vscode.workspace.openTextDocument(testFilePath);
+		await vscode.window.showTextDocument(document);
+
+		// Execute the clear-outputs-file command
+		await vscode.commands.executeCommand('clear-outputs-file');
+
+		// Get the updated content of the file
+		const updatedDocument = await vscode.workspace.openTextDocument(testFilePath);
+		const updatedContent = updatedDocument.getText();
+
+		// Verify that console.log has been removed
+		assert.strictEqual(updatedContent.includes('console.log("test");'), false);
+
+		// Limpiar: cerrar el editor y eliminar el archivo de prueba
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+		fs.unlinkSync(testFilePath);
+	});
+
+	// Verificar que el comando clear-outputs-project se ejecute correctamente en cpp
+	test('clear-outputs-file removes cout', async () => {
+		// Ruta del archivo de prueba y su contenido
+		const testFilePath = path.join(__dirname, 'testFile.cpp');
+		const testContent = 'std::cout << "test";\ncout << "test";';
+
+		// Crear un archivo de prueba con cout
+		fs.writeFileSync(testFilePath, testContent);
+
+		// Abrir el archivo de prueba en el editor
+		const document = await vscode.workspace.openTextDocument(testFilePath);
+		await vscode.window.showTextDocument(document);
+
+		// Ejecutar el comando clear-outputs-file
+		await vscode.commands.executeCommand('clear-outputs-file');
+
+		// Obtener el contenido actualizado del archivo
+		const updatedDocument = await vscode.workspace.openTextDocument(testFilePath);
+		const updatedContent = updatedDocument.getText();
+
+		// Verificar que cout ha sido eliminado
+		assert.strictEqual(updatedContent.includes('std::cout << "test";'), false);
+		assert.strictEqual(updatedContent.includes('cout << "test";'), false);
+
+		// Limpiar: cerrar el editor y eliminar el archivo de prueba
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+		fs.unlinkSync(testFilePath);
 	});
 });


### PR DESCRIPTION
Como dice el commit puse std opcional ya que no es obligatorio si utilizas 
 using namespace std, que es muy común.

Tambien cambie clearAllOutputsCommandFile para que no tengas que selecionar en que lengauje te encuentras, porque se me hacía un poco molesto ue cada vez que quería eliminar los ouputs del archivo actual, tener que hacer ese paso adicional.

En clearAllOutputsCommandProject si que deverias selecionarlo, tiene sentido porque no tiene porque que los ouputs que queiras eliminar tengan que ser los selecionado en el archivo.

Se me olvidaba tambien puse test, no afetcan al funcionameinto solo comprueba que funcione el current file en javascript y cpp.